### PR TITLE
Revert "Fix hyperactive linkchecker"

### DIFF
--- a/.github/workflows/validate-mkdocs.yml
+++ b/.github/workflows/validate-mkdocs.yml
@@ -27,5 +27,5 @@ jobs:
             --check-html
             --http-status-ignore 302
             --file-ignore ./site/404.html
-            --url-ignore "https://fonts.gstatic.com,/github.com\/osg-htc\/${{ steps.format-github-repo.outputs.repo-name }}\/edit/,/osg-htc.org\/${{ steps.format-github-repo.outputs.repo-name }}/"
+            --url-ignore "https://fonts.gstatic.com,/github.com\/opensciencegrid\/${{ steps.format-github-repo.outputs.repo-name }}\/edit/,/opensciencegrid.org\/${{ steps.format-github-repo.outputs.repo-name }}/"
             ./site


### PR DESCRIPTION
Reverts osg-htc/security#20

This change seems to have broken something with our process to update security announcements, so I'm backing it out.