### PR TITLE
Adding new announcement

### DIFF
--- a/docs/OSGSecurityAnnouncements.md
+++ b/docs/OSGSecurityAnnouncements.md
@@ -1,5 +1,6 @@
 | Date        | Title                                                 | Contents/Link       |   Risk        |
 |-------------|-------------------------------------------------------|---------------------|---------------|
+| 2026-06-17  | Critical libssh2 RCE Vulnerability (CVE-2026-55200)  | [OSG-SEC-2026-06-17](./vulns/OSG-SEC-2026-06-17.md) |     |
 | 2026-06-23  | Important privilege escalation flaw in act_pedit   | [OSG-SEC-2026-06-23](./vulns/OSG-SEC-2026-06-23.md) |     |
 | 2026-06-11  | Critical flaw in the Linux kernel's IPv6 tunneling   | [OSG-SEC-2026-06-11a](./vulns/OSG-SEC-2026-06-11a.md) |     |
 | 2026-06-11  | IPv6 ICMP Error Handling Vulnerability  | [OSG-SEC-2026-06-11](./vulns/OSG-SEC-2026-06-11.md) |     |

--- a/docs/vulns/OSG-SEC-2026-06-17.md
+++ b/docs/vulns/OSG-SEC-2026-06-17.md
@@ -1,0 +1,35 @@
+## Critical libssh2 RCE Vulnerability (CVE-2026-55200)
+
+Dear OSG Security Contacts,
+
+A critical remote code execution vulnerability has been identified in the libssh2 SSH client library (CVE-2026-55200). A malicious SSH server may be able to exploit this flaw during SSH connection establishment, potentially allowing arbitrary code execution on a vulnerable client system before host key authentication has completed. Since libssh2 is widely used by applications that perform SSH, SCP, and SFTP communications, a broad range of software products and services may be affected. 
+
+## WHAT ARE THE VULNERABILITIES:
+CVE-2026-55200 is a critical out-of-bounds write vulnerability in libssh2. The vulnerability occurs during SSH transport processing when specially crafted server responses can trigger memory corruption in a vulnerable client. A malicious SSH server can exploit this condition to corrupt memory and potentially execute arbitrary code on a vulnerable client system during connection establishment (before user authentication or host key authentication.)
+A second vulnerability, CVE-2026-55199, may allow a malicious SSH server to cause excessive CPU utilization and denial of service in vulnerable clients during SSH key exchange processing.
+These vulnerabilities affect client-side software that relies on libssh2 for SSH, SCP, or SFTP communications.
+
+## IMPACTED VERSIONS:  
+libssh2 versions 1.11.1 and earlier are affected.   
+Applications that bundle or statically link libssh2 may also be vulnerable and may require vendor-specific updates.   
+Administrators should review software dependencies and consult vendor advisories to determine whether affected versions of libssh2 are present.    
+
+## WHAT YOU SHOULD DO:   
+
+- Apply vendor-provided updates containing fixes for CVE-2026-55200 and CVE-2026-55199 as they become available.   
+- Administrators should inventory systems and applications that depend on libssh2, including software that performs SSH, SCP, or SFTP operations. Particular attention should be given to third-party applications and appliances that include their own copy of libssh2, as operating system updates alone may not address the vulnerability.    
+- Review automated workflows, data transfer services, backup processes, and other applications that establish SSH-based connections to external systems. Where practical, limit connections to trusted SSH servers until updates have been applied.    
+- Monitor vendor security advisories for products that include libssh2 and apply remediation updates as they become available.   
+
+
+## REFERENCES
+
+[1] https://www.cve.org/CVERecord?id=CVE-2026-55200    
+[2] https://nvd.nist.gov/vuln/detail/CVE-2026-55200   
+[3] https://nvd.nist.gov/vuln/detail/CVE-2026-55199   
+[4] https://www.vulncheck.com/advisories/libssh2-out-of-bounds-write-via-unchecked-packet-length-in-transport-c   
+[5]  https://github.com/libssh2/libssh2/commit/97acf3dfda80c91c3a8c9f2372546301d4a1a7a8   
+
+Please contact the OSG security team at security@osg-htc.org if you have any questions or concerns.
+
+OSG Security Team 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Overview: 'OSGSecurityAnnouncements.md'
   - Overview x86 vulnerabilities: 'OSGSecurityAnnouncements-x86.md'
 - Announcement Details:
+    - OSG-SEC-2026-06-17 Critical libssh2 RCE Vulnerability (CVE-2026-55200) : './vulns/OSG-SEC-2026-06-17.md'
     - OSG-SEC-2026-06-23 Important privilege escalation flaw in act_pedit : './vulns/OSG-SEC-2026-06-23.md'
     - OSG-SEC-2026-06-11a Critical flaw in the Linux kernel's IPv6 tunneling : './vulns/OSG-SEC-2026-06-11a.md'
     - OSG-SEC-2026-06-11 IPv6 ICMP Error Handling Vulnerability: './vulns/OSG-SEC-2026-06-11.md'


### PR DESCRIPTION
Critical libssh2 RCE Vulnerability (CVE-2026-55200)